### PR TITLE
fmt: improve formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 build:
 	go build -v -o bin/boa ./cmd/boa
 
+install:
+	go install -v ./cmd/boa
+
 test:
 	go test -v ./...
 
@@ -9,4 +12,3 @@ golden:
 
 lint:
 	golangci-lint run
-

--- a/cmd/boa/boa.go
+++ b/cmd/boa/boa.go
@@ -38,7 +38,7 @@ func main() {
 		newVersion(cmd),
 	)
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/boa/completion.go
+++ b/cmd/boa/completion.go
@@ -52,7 +52,6 @@ To permanently add bash autocompletion, run:
 			}
 		},
 	}
-
 	cmd.Flags().StringVar(&flags.shell, "shell", "bash", "Shell type (bash|zsh|fish)")
 	return cmd
 }

--- a/cmd/boa/testdata/init/completion.go
+++ b/cmd/boa/testdata/init/completion.go
@@ -52,7 +52,6 @@ To permanently add bash autocompletion, run:
 			}
 		},
 	}
-
 	cmd.Flags().StringVar(&flags.shell, "shell", "bash", "Shell type (bash|zsh|fish)")
 	return cmd
 }

--- a/cmd/boa/testdata/init/server.go
+++ b/cmd/boa/testdata/init/server.go
@@ -37,7 +37,7 @@ func main() {
 		newVersion(cmd),
 	)
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/tmpl/completion.go
+++ b/pkg/tmpl/completion.go
@@ -17,7 +17,6 @@ package tmpl
 const Completion = `{{ if .Copyright.Author }}// Copyright {{.Copyright.Year}} {{ .Copyright.Author }}{{ end }}
 {{ if .License.Commented }}{{ .License.Commented }}{{ end }}
 
-
 package main
 
 import (
@@ -58,7 +57,6 @@ To permanently add bash autocompletion, run:
 			}
 		},
 	}
-
 	cmd.Flags().StringVar(&flags.shell, "shell", "bash", "Shell type (bash|zsh|fish)")
 	return cmd
 }

--- a/pkg/tmpl/root.go
+++ b/pkg/tmpl/root.go
@@ -17,8 +17,6 @@ package tmpl
 const Root = `{{ if .Copyright.Author }}// Copyright {{.Copyright.Year}} {{ .Copyright.Author }}{{ end }}
 {{ if .License.Commented }}{{ .License.Commented }}{{ end }}
 
-
-
 package main
 
 import (
@@ -44,7 +42,7 @@ func main() {
 		newVersion(cmd),
 	)
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", err)
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Improve formatting of templated code.
Add a newline when printing an error in the root command.